### PR TITLE
Fix common.getExteriorCell. 

### DIFF
--- a/00 Data Files/MWSE/mods/TamrielData/common.lua
+++ b/00 Data Files/MWSE/mods/TamrielData/common.lua
@@ -12,18 +12,27 @@ function table.contains(table, element)
 	return false
 end
 
----@param cell tes3cell
+--- @param cell tes3cell
+--- @param cellVisitTable table<tes3cell, boolean>|nil
+--- @return tes3cell?
 function this.getExteriorCell(cell, cellVisitTable)
 	if cell.isOrBehavesAsExterior then
 		return cell
 	end
 
-	cellVisitTable = cellVisitTable or { tes3.player.cell }
-	
+	-- A hashset of cells that have already been checked, to prevent infinite loops and redundant checks.
+	cellVisitTable = cellVisitTable or {}
+	if (cellVisitTable[cell]) then
+		return
+	end
+	cellVisitTable[cell] = true
+
 	for ref in cell:iterateReferences(tes3.objectType.door) do
-		if ref.destination and not table.contains(cellVisitTable, ref.destination.cell) then
-			table.insert(cellVisitTable, ref.destination.cell)
-			return this.getExteriorCell(ref.destination.cell, cellVisitTable)
+		if ref.destination and ref.destination.cell then
+			local linkedExterior = this.getExteriorCell(ref.destination.cell, cellVisitTable)
+			if (linkedExterior) then
+				return linkedExterior
+			end
 		end
 	end
 end


### PR DESCRIPTION
It no longer stops on the first destination. It is still depth-first in its search, which is probably not ideal. In theory you could have a tunnel leading through a mountain, and get the far end of the mountain instead of the door right next to the player. But, this will at least work for self-contained dungeons with more than one load door. Tested from `Kemel-Ze, Azmvat`, which seemed properly tangled.

Old:
```
Checking cell: Kemel-Ze, Azmvat
Checking cell: Kemel-Ze, Chefidz
Checking cell: Kemel-Ze, Dizfchurmz
Checking cell: Kemel-Ze, Veil of Heartfire
Checking cell: Kemel-Ze, Chefidz Bassin
Checking cell: Kemel-Ze, Render's Walk
Checking cell: Kemel-Ze, Hall of Reason
Checking cell: Kemel-Ze, Chimes of the Sculptor
Checking cell: Kemel-Ze, Chorus of the Maker
No exterior found.
```

New:
```
Checking cell: Kemel-Ze, Azmvat
Checking cell: Kemel-Ze, Chefidz
Checking cell: Kemel-Ze, Dizfchurmz
Checking cell: Kemel-Ze, Veil of Heartfire
Checking cell: Kemel-Ze, Chefidz Bassin
Checking cell: Kemel-Ze, Render's Walk
Checking cell: Kemel-Ze, Hall of Reason
Checking cell: Kemel-Ze, Chimes of the Sculptor
Checking cell: Kemel-Ze, Chorus of the Maker
Checking cell: Kemel-Ze, Pillar of Learning
Checking cell: Kemel-Ze, Stafaznir
Checking cell: Kemel-Ze, Btharkhz
Checking cell: Kemel-Ze, Vels
Checking cell: Kemel-Ze, Archaeologist Base
Checking cell: Kemel-Ze, Carkurngth
Checking cell: Kemel-Ze, Cells of Scarab's Pass
Checking cell: Kemel-Ze, Aster
Checking cell: Kemel-Ze, Bzntch
Checking cell: Kemel-Ze, Dzuran
Checking cell: Kemel-Ze, Shorebreak Well
Checking cell: Kemel-Ze, Chuntench
Checking cell: Kemel-Ze, Runzchuk
Checking cell: Kemel-Ze (22, -2)
Found exterior: Kemel-Ze (22, -2)
```